### PR TITLE
Feature/signup and signin#5

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -104,3 +104,37 @@ body {
     color: #0075c1;
   }
 }
+
+// sign_in
+.signinPage {
+  margin-top: 10vh;
+  .title {
+    margin: 0;
+    text-align: center;
+  }
+  .new_user {
+    .form-group {
+      max-width: 500px;
+      margin: 0 auto 1rem;
+      .form-control {
+        background: #f6f8fa;
+      }
+    }
+  }
+  .loginBtn {
+    padding: 12px;
+    width: 200px;
+    border-radius: 21px;
+    background: #29b744;
+    color: #fff;
+    text-align: center;
+    border: none;
+    margin-top: 20px;
+    opacity: 1;
+    transition: opacity .5s;
+    cursor: pointer;
+    &:hover {
+      opacity: .7;
+    }
+  }
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -52,3 +52,55 @@ body {
     }
   }
 }
+
+// button
+.submitBtn {
+  background: #29b744;
+  color: #fff;
+  width: 200px;
+  margin-top: 20px;
+  padding: 10px;
+  border-radius: 90px;
+  transition: opacity .5s;
+  cursor: pointer;
+  &:hover {
+    opacity: .6;
+  }
+}
+
+// sign_up
+.sinupPage {
+  margin-top: 10vh;
+  .titleArea {
+    text-align: center;
+    h1 {font-size: 2rem;}
+  }
+  .signupForm {
+    .form-group {
+      margin: 0 auto 1.5rem auto;
+      max-width: 500px;
+      .form-control {
+        background: #f6f8fa;
+      }
+    }
+  }
+  .submitBtn {
+    background: #29b744;
+    color: #fff;
+    width: 200px;
+    margin-top: 20px;
+    padding: 10px;
+    border-radius: 90px;
+    transition: opacity .5s;
+    &:hover {
+      opacity: .6;
+    }
+  }
+}
+
+// devise_shared_links
+.acountPage_link {
+  & > a {
+    color: #0075c1;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+
+  before_action :authenticate_user!
+  
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :authenticate_user!
-  before_action :counfigure_permitted_parameters, if: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
@@ -11,5 +11,5 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
       devise_parameter_sanitizer.permit(:account_update, keys: [:name])
     end
-    
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,15 @@
 class ApplicationController < ActionController::Base
 
+  protect_from_forgery with: :exception
+
   before_action :authenticate_user!
-  
+  before_action :counfigure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    end
+    
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :name, presence: true, length: { maximum: 20 }
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,21 +1,26 @@
-%h2 Sign up
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      %em
-        (#{@minimum_password_length} characters minimum)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .actions
-    = f.submit "Sign up"
-= render "devise/shared/links"
+.sinupPage
+  .titleArea
+    %h1 アカウントを新規作成
+    .m-3 or
+    = render "devise/shared/links"
+  .container
+    = form_with scope: resource, as: resource_name, url: registration_path(resource_name), html: { class: "mt-5, signupForm" }, local: true do |f|
+      = devise_error_messages!
+      .form-group
+        = f.label :name
+        = f.text_field :name, class: "form-control", placeholder: "名前を入力してください"
+      .form-group
+        = f.label :email
+        = f.email_field :email, class: "form-control", placeholder: "emailを入力してください" ,autocomplete: "email"
+      .form-group
+        = f.label :password
+        - if @minimum_password_length
+          %em
+            (#{@minimum_password_length}文字以上入力してください)
+        %br/
+        = f.password_field :password, class: "form-control", placeholder:"パスワードを入力してください", autocomplete: "off"
+      .form-group
+        = f.label :password_confirmation
+        = f.password_field :password_confirmation, class:"form-control", placeholder: "パスワードを再度入力してください", autocomplete: "off"
+      .text-center
+        = f.submit "アカウントを作成", class: "btn submitBtn"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,16 @@
-%h2 Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    %br/
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.signinPage
+  .container
+    %h2.title kanbanにサインイン
+    .text-center.m-3 or
+    .text-center= render "devise/shared/links"
+    = form_with scope: resource, as: resource_name, url: session_path(resource_name), html: { class: "mt-5, new_user" }, local: true do |f|
+      .form-group
+        = f.label :email
+        %br/
+        = f.email_field :email, autofocus: true, class: "form-control", autocomplete: "email", placeholder: "emailを入力してください"
+      .form-group
+        = f.label :password
+        %br/
+        = f.password_field :password, class: "form-control", autocomplete: "off", placeholder: "パスワードを入力してください"
+      .form-group.text-center
+        = f.submit "サインイン", class: "loginBtn"

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -2,10 +2,14 @@
   %p.acountPage_link= link_to "アカウントにサインイン", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  %p.acountPage_link= link_to "アカウントを作成", new_registration_path(resource_name)
+/
+  <haml_silent> if devise_mapping.recoverable? &amp;&amp; controller_name != &#39;passwords&#39; &amp;&amp; controller_name != &#39;registrations&#39; </haml_silent><haml_block>
+  <haml_loud> link_to &quot;Forgot your password?&quot;, new_password_path(resource_name) </haml_loud><br />
+  </haml_block>
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to "パスワードを忘れた", new_password_path(resource_name)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
+  %p.acountPage_link= link_to "アカウントにサインイン", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to "Sign up", new_registration_path(resource_name)

--- a/app/views/partial/_header.html.haml
+++ b/app/views/partial/_header.html.haml
@@ -2,7 +2,9 @@
   %header.header
     %nav.nav
       %ul.header_menu
-        %li.nav-link username
+        %li.nav-link
+          = current_user.name
+          さん
         %li.header_menu_title= link_to "kanban", root_path, class: "nav-link"
         %li
           %ul.header_menu_inner

--- a/app/views/partial/_header.html.haml
+++ b/app/views/partial/_header.html.haml
@@ -7,4 +7,4 @@
         %li
           %ul.header_menu_inner
             %li= link_to "リストを作成", "#", class: "nav-link listNew"
-            %li= link_to "サインアウト", "#", class: "nav-link"
+            %li= link_to "サインアウト", destroy_user_session_path, class: "nav-link", method: :delete

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Todo
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        name: "お名前"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+        email: "メールアドレス"

--- a/db/migrate/20200714074512_add_name_to_user.rb
+++ b/db/migrate/20200714074512_add_name_to_user.rb
@@ -1,0 +1,5 @@
+class AddNameToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/migrate/20200714074512_add_name_to_user.rb
+++ b/db/migrate/20200714074512_add_name_to_user.rb
@@ -1,5 +1,5 @@
 class AddNameToUser < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :name, :string
+    add_column :users, :name, :string, null: false, default: ""
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_14_065135) do
+ActiveRecord::Schema.define(version: 2020_07_14_074512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2020_07_14_065135) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
fixes #5 

# Summary

- サインアウトのリンクを追加
- サインインしていないときサインインページにリダイレクトさせる
- usersテーブルにnameカラムを追加
- サインアップページのビューを作る
- サインアップページのscssを追加
- 日本語表記にする（サインインリンクやフォーム）
- サインインページのビューを作る
- サインインページのscssを追加
- ヘッダーにユーザーネームを表示

# Note

Strong parameter参考ページ
cf. heartcombo/devise#strong-parameters